### PR TITLE
Make DataMatrix codes square by default like Labelary

### DIFF
--- a/internal/drawers/barcode_datamatrix.go
+++ b/internal/drawers/barcode_datamatrix.go
@@ -30,10 +30,10 @@ func NewBarcodeDatamatrixDrawer() *ElementDrawer {
 			}
 
 			switch barcode.Ratio {
-			case elements.DatamatrixRatioSquare:
-				opts.Shape = encoder.SymbolShapeHint_FORCE_SQUARE
 			case elements.DatamatrixRatioRectangular:
 				opts.Shape = encoder.SymbolShapeHint_FORCE_RECTANGLE
+			default: // This includes 0 (unset) and 1 (square) - default to square like Labelary
+				opts.Shape = encoder.SymbolShapeHint_FORCE_SQUARE
 			}
 
 			data := barcode.Data


### PR DESCRIPTION
- Change default behavior to force square shapes when ratio is unset
- Only use rectangular shapes when explicitly set to ratio=2
- Update test PNG to reflect new square DataMatrix rendering
