### PR TITLE
barcode_qr: offset when default barcode dimensions was set

### DIFF
--- a/internal/drawers/barcode_qr.go
+++ b/internal/drawers/barcode_qr.go
@@ -38,7 +38,7 @@ func NewBarcodeQrDrawer() *ElementDrawer {
 			scaledImg := images.NewScaled(img, barcode.Magnification, barcode.Magnification)
 			pos := adjustImageTypeSetPosition(scaledImg, barcode.Position, elements.FieldOrientationNormal)
 
-			gCtx.DrawImage(scaledImg, pos.X, pos.Y)
+			gCtx.DrawImage(scaledImg, pos.X, pos.Y+barcode.Height)
 
 			return nil
 		},

--- a/internal/elements/barcode_qr.go
+++ b/internal/elements/barcode_qr.go
@@ -9,6 +9,7 @@ type BarcodeQr struct {
 	// Any number between 1 and 10 may be used.
 	// The default value depends on the print density being used.
 	Magnification int
+	Height        int
 }
 
 type BarcodeQrWithData struct {

--- a/internal/parsers/barcode_field_defaults.go
+++ b/internal/parsers/barcode_field_defaults.go
@@ -27,7 +27,7 @@ func NewBarcodeFieldDefaults() *CommandParser {
 			}
 
 			if len(parts) > 2 {
-				if v, err := strconv.Atoi(parts[2]); err == nil {
+				if v, err := strconv.Atoi(strings.Trim(parts[2], " ")); err == nil {
 					printer.DefaultBarcodeDimensions.Height = v
 				}
 			}

--- a/internal/parsers/barcode_qr.go
+++ b/internal/parsers/barcode_qr.go
@@ -16,6 +16,7 @@ func NewBarcodeQrParser() *CommandParser {
 		Parse: func(command string, printer *printers.VirtualPrinter) (any, error) {
 			barcode := &elements.BarcodeQr{
 				Magnification: 1,
+				Height:        printer.DefaultBarcodeDimensions.Height,
 			}
 
 			parts := splitCommand(command, code, 0)


### PR DESCRIPTION
Same offset (Y) like in labelary.com on ^BY command third parameter. For example:
```
^XA
^BY3,2,100       
^FO0,0^BQN,2,8^FDEXAMPLE CODE^FS
^XZ
```
