### PR TITLE
Split text and field alignment

### DIFF
--- a/internal/drawers/text_field.go
+++ b/internal/drawers/text_field.go
@@ -129,13 +129,8 @@ func getTextAxAy(text *elements.TextField) (float64, float64) {
 	ax := 0.0
 	ay := 0.0
 
-	switch text.Alignment {
-	case elements.TextAlignmentLeft, elements.TextAlignmentJustified:
-		ax = 0
-	case elements.TextAlignmentRight:
+	if text.Alignment == elements.FieldAlignmentRight {
 		ax = 1
-	case elements.TextAlignmentCenter:
-		ax = 0.5
 	}
 
 	return ax, ay

--- a/internal/elements/field_alignment.go
+++ b/internal/elements/field_alignment.go
@@ -1,0 +1,12 @@
+package elements
+
+// The origin alignment to use.
+// Not the same as text alignment for text block
+type FieldAlignment int
+
+const (
+	FieldAlignmentLeft  FieldAlignment = 0
+	FieldAlignmentRight FieldAlignment = 1
+	// automatic alignment based on the direction of the field data text
+	FieldAlignmentAuto FieldAlignment = 2
+)

--- a/internal/elements/text_field.go
+++ b/internal/elements/text_field.go
@@ -5,7 +5,7 @@ type TextField struct {
 
 	Font      FontInfo
 	Position  LabelPosition
-	Alignment TextAlignment
+	Alignment FieldAlignment
 	Text      string
 	Block     *FieldBlock
 }

--- a/internal/parsers/command_parser.go
+++ b/internal/parsers/command_parser.go
@@ -43,6 +43,23 @@ func toFieldOrientation(orientation byte) elements.FieldOrientation {
 	}
 }
 
+func toFieldAlignment(alignment string) (elements.FieldAlignment, bool) {
+	v, err := strconv.Atoi(alignment)
+
+	if err == nil {
+		switch v {
+		case 0:
+			return elements.FieldAlignmentLeft, true
+		case 1:
+			return elements.FieldAlignmentRight, true
+		case 2:
+			return elements.FieldAlignmentAuto, true
+		}
+	}
+
+	return elements.FieldAlignmentLeft, false
+}
+
 func toTextAlignment(alignment byte) elements.TextAlignment {
 	switch alignment {
 	case 'L':

--- a/internal/parsers/field_block.go
+++ b/internal/parsers/field_block.go
@@ -17,7 +17,7 @@ func NewFieldBlockParser() *CommandParser {
 				MaxWidth:      0,
 				MaxLines:      1,
 				LineSpacing:   0,
-				Alignment:     printer.GetNextElementAlignmentOrDefault(),
+				Alignment:     elements.TextAlignmentLeft,
 				HangingIndent: 0,
 			}
 

--- a/internal/parsers/field_orientation.go
+++ b/internal/parsers/field_orientation.go
@@ -17,7 +17,9 @@ func NewFieldOrientationParser() *CommandParser {
 			}
 
 			if len(parts) > 1 && len(parts[1]) > 0 {
-				printer.DefaultAlignment = toTextAlignment(parts[1][0])
+				if val, ok := toFieldAlignment(parts[1]); ok {
+					printer.DefaultAlignment = val
+				}
 			}
 
 			return nil, nil

--- a/internal/parsers/field_origin.go
+++ b/internal/parsers/field_origin.go
@@ -1,8 +1,6 @@
 package parsers
 
 import (
-	"strconv"
-
 	"github.com/ingridhq/zebrash/internal/elements"
 	"github.com/ingridhq/zebrash/internal/printers"
 )
@@ -32,18 +30,8 @@ func NewFieldOriginParser() *CommandParser {
 			}
 
 			if len(parts) > 2 {
-				if v, err := strconv.Atoi(parts[2]); err == nil {
-					switch v {
-					case 0:
-						val := elements.TextAlignmentLeft
-						printer.NextElementAlignment = &val
-					case 1:
-						val := elements.TextAlignmentRight
-						printer.NextElementAlignment = &val
-					case 2:
-						val := elements.TextAlignmentJustified
-						printer.NextElementAlignment = &val
-					}
+				if val, ok := toFieldAlignment(parts[2]); ok {
+					printer.NextElementAlignment = &val
 				}
 			}
 

--- a/internal/parsers/field_typeset.go
+++ b/internal/parsers/field_typeset.go
@@ -1,8 +1,6 @@
 package parsers
 
 import (
-	"strconv"
-
 	"github.com/ingridhq/zebrash/internal/elements"
 	"github.com/ingridhq/zebrash/internal/printers"
 )
@@ -35,18 +33,8 @@ func NewFieldTypesetParser() *CommandParser {
 			}
 
 			if len(parts) > 2 {
-				if v, err := strconv.Atoi(parts[2]); err == nil {
-					switch v {
-					case 0:
-						val := elements.TextAlignmentLeft
-						printer.NextElementAlignment = &val
-					case 1:
-						val := elements.TextAlignmentRight
-						printer.NextElementAlignment = &val
-					case 2:
-						val := elements.TextAlignmentJustified
-						printer.NextElementAlignment = &val
-					}
+				if val, ok := toFieldAlignment(parts[2]); ok {
+					printer.NextElementAlignment = &val
 				}
 			}
 

--- a/internal/printers/virtual.go
+++ b/internal/printers/virtual.go
@@ -10,8 +10,8 @@ type VirtualPrinter struct {
 	NextElementPosition      elements.LabelPosition
 	DefaultFont              elements.FontInfo
 	DefaultOrientation       elements.FieldOrientation
-	DefaultAlignment         elements.TextAlignment
-	NextElementAlignment     *elements.TextAlignment
+	DefaultAlignment         elements.FieldAlignment
+	NextElementAlignment     *elements.FieldAlignment
 	NextElementFieldElement  any
 	NextElementFieldData     string
 	NextFont                 *elements.FontInfo
@@ -30,6 +30,7 @@ func NewVirtualPrinter() *VirtualPrinter {
 		DefaultFont: elements.FontInfo{
 			Name: "A",
 		}.WithAdjustedSizes(),
+		DefaultAlignment: elements.FieldAlignmentLeft,
 		DefaultBarcodeDimensions: elements.BarcodeDimensions{
 			ModuleWidth: 2,
 			Height:      10,
@@ -54,7 +55,7 @@ func (p *VirtualPrinter) GetNextFontOrDefault() elements.FontInfo {
 	return p.DefaultFont
 }
 
-func (p *VirtualPrinter) GetNextElementAlignmentOrDefault() elements.TextAlignment {
+func (p *VirtualPrinter) GetNextElementAlignmentOrDefault() elements.FieldAlignment {
 	if p.NextElementAlignment != nil {
 		return *p.NextElementAlignment
 	}


### PR DESCRIPTION
Text alignment set by ^FB and field alignment set by ^FO, ^FT or ^FW  are 2 separate things and were merged together by mistake
Refactoring the code and splitting them into separate entities