### PR TITLE
fix: respect FieldBlock max line count on draw

### DIFF
--- a/internal/drawers/text_field.go
+++ b/internal/drawers/text_field.go
@@ -55,7 +55,7 @@ func NewTextFieldDrawer() *ElementDrawer {
 
 			if text.Block != nil {
 				maxWidth := float64(text.Block.MaxWidth) / scaleX
-				drawStringWrapped(gCtx, text.Text, x, y-h, ax, ay, maxWidth, 1+float64(text.Block.LineSpacing)/h, text.Block.Alignment)
+				drawStringWrapped(gCtx, text.Text, x, y-h, ax, ay, maxWidth, 1+float64(text.Block.LineSpacing)/h, text.Block.Alignment, text.Block.MaxLines)
 			} else {
 				gCtx.DrawStringAnchored(text.Text, x, y, ax, ay)
 			}
@@ -155,9 +155,12 @@ func mustLoadFont(fontData []byte) *truetype.Font {
 }
 
 // Similar to gCtx.DrawStringWrapped but supports justified alignment
-func drawStringWrapped(gCtx *gg.Context, s string, x, y, ax, ay, width, lineSpacing float64, align elements.TextAlignment) {
+func drawStringWrapped(gCtx *gg.Context, s string, x, y, ax, ay, width, lineSpacing float64, align elements.TextAlignment, maxLines int) {
 	fontHeight := gCtx.FontHeight()
 	lines := gCtx.WordWrap(s, width)
+	if len(lines) > maxLines {
+		lines = lines[:maxLines]
+	}
 
 	h := float64(len(lines)) * fontHeight * lineSpacing
 	h -= (lineSpacing - 1) * fontHeight


### PR DESCRIPTION
Ensure FieldBlock MaxLines value is enforced when drawing of TextField. 

The fix truncates the string array returned by ggContext.WordWrap to the maximum line count defined in FieldBlock